### PR TITLE
Added fix jumping zoomed image of new browsers chromium

### DIFF
--- a/jquery.spzoom.js
+++ b/jquery.spzoom.js
@@ -93,7 +93,7 @@
 
         this.$zoom = $('<div class="spzoom-zoom"/>').css({
             'box-sizing': 'border-box',
-            'position': 'absolute',
+            //'position': 'absolute',
             'top': 0,
             'left': 0,
             'overflow': 'hidden',
@@ -302,7 +302,8 @@
         this.$zoom.css({
             'width': this.options.width,
             'height': this.options.height,
-            'visibility': 'visible'
+            'visibility': 'visible',
+            'position': 'absolute'
         });
     };
 


### PR DESCRIPTION
I found a problem on new versions of chrome. There was a jump in the image from the bottom to the top and vice versa. Work has been done to find and fix this problem. She covered herself in absolute positioning on the element